### PR TITLE
dashboardに必要なリソースを作成する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+
 .idea
 datadog-terraform-sample.iml
+terraform.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+datadog-terraform-sample.iml

--- a/dashboard/main.tf
+++ b/dashboard/main.tf
@@ -1,0 +1,35 @@
+resource "datadog_timeboard" "fargate" {
+  title       = "Fargate created by Terraform"
+  description = "Fargate created by Terraform"
+  read_only   = true
+
+  graph {
+    title = "CPU Percent"
+    viz   = "timeseries"
+
+    request {
+      q    = "avg:ecs.fargate.cpu.percent{ecs_container_name:php}"
+      type = "lines"
+    }
+
+    request {
+      q    = "avg:ecs.fargate.cpu.percent{ecs_container_name:nginx}"
+      type = "lines"
+    }
+  }
+
+  graph {
+    title = "Memory Usage"
+    viz   = "timeseries"
+
+    request {
+      q    = "avg:ecs.fargate.mem.usage{ecs_container_name:php}"
+      type = "lines"
+    }
+
+    request {
+      q    = "avg:ecs.fargate.mem.usage{ecs_container_name:nginx}"
+      type = "lines"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,3 @@
+module "dashboard" {
+  source = "./dashboard"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,7 @@
+variable "datadog_api_key" {}
+variable "datadog_app_key" {}
+
+provider "datadog" {
+  api_key = "${var.datadog_api_key}"
+  app_key = "${var.datadog_app_key}"
+}


### PR DESCRIPTION
## やったこと
Fargateのコンテナを監視するためのダッシュボードを作成。
タスク単位(PHP,Nginx)で`ecs.fargate.cpu.percent`、`ecs.fargate.mem.usag`をグラフに表示するリソースを追加。

<img width="1267" alt="スクリーンショット 2019-06-12 18 37 03" src="https://user-images.githubusercontent.com/32682645/59340529-24b8eb00-8d41-11e9-9136-520ebd8553c7.png">

## 補足
いきなりTerraformでダッシュボードを作成するのではなく、GUIで作成してからTerraformで管理する方法が良さそう。
[DatadogのDashboardやMonitorをTerraform化する](https://qiita.com/knqyf263/items/bd5b12d17b7e6db89eb5)で紹介されている、https://github.com/amnk/dd2tf も検討する。
