### PR TITLE
CPU使用率の異常値を検知した際にSlackに通知するリソースを作成する

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
 module "dashboard" {
   source = "./dashboard"
 }
+
+module "monitor" {
+  source = "./monitor"
+}

--- a/monitor/main.tf
+++ b/monitor/main.tf
@@ -1,0 +1,22 @@
+resource "datadog_monitor" "fargate_high_cpu_percent" {
+  name               = "High CPU Percent of Docker"
+  type               = "metric alert"
+  message            = "Fargate High CPU Percent @${var.slack_channel_name}"
+  escalation_message = ""
+
+  query = "max(last_1m):avg:ecs.fargate.cpu.percent{*} > 1"
+
+  thresholds {
+    critical = 1
+  }
+
+  notify_no_data    = false
+  renotify_interval = 0
+
+  notify_audit = false
+  timeout_h    = 0
+  include_tags = true
+
+  require_full_window = false
+  new_host_delay      = 300
+}

--- a/monitor/variable.tf
+++ b/monitor/variable.tf
@@ -1,0 +1,4 @@
+variable "slack_channel_name" {
+  type    = "string"
+  default = "slack-datadog"
+}


### PR DESCRIPTION
## やったこと
CPU使用率の異常値を検知した際にSlackに通知するリソースを作成
検証のため、閾値は極端に低い値に設定している。

Slackの通知例
 
<img width="592" alt="スクリーンショット 2019-06-13 21 46 48" src="https://user-images.githubusercontent.com/32682645/59433585-d11fcd80-8e24-11e9-868c-a1289336fb35.png">

<img width="537" alt="スクリーンショット 2019-06-13 21 47 31" src="https://user-images.githubusercontent.com/32682645/59433620-e5fc6100-8e24-11e9-82c9-266fd6fa6709.png">


## 補足
### 事前設定
Slackに通知するために、事前に下記の設定を行なっておくこと
1. SlackにDatadogのIntegrationを追加
DatadogのIntegrationを追加すると、Datadogへの設定方法が表示されます。

<img width="1053" alt="スクリーンショット 2019-06-13 20 20 16" src="https://user-images.githubusercontent.com/32682645/59430373-0de7c680-8e1d-11e9-9251-f664e25c05af.png">

<img width="853" alt="スクリーンショット 2019-06-13 20 23 19" src="https://user-images.githubusercontent.com/32682645/59430393-1b04b580-8e1d-11e9-95c3-c4a6ba51f0e9.png">

2.DatadogのSlack Integrationを追加
`Slack Account Hook`に、1.で表示された手順に記載されているURLを貼り付けます。
必要に応じて、SlackのChannnelを追加します。
下記の例では、Channnelに`datadog`を追加したので、`@slack-datadog`でSlackに通知することが可能です。

![スクリーンショット 2019-06-13 20 55 29](https://user-images.githubusercontent.com/32682645/59430666-dcbbc600-8e1d-11e9-8efb-a5756ab475d8.png)

<img width="1028" alt="スクリーンショット 2019-06-13 20 54 12" src="https://user-images.githubusercontent.com/32682645/59430531-73d44e00-8e1d-11e9-8762-d677f45b7815.png">

### タスクの停止時のイベント取得
Fargate Integrationで取得できるメトリクスは下記の通り。
https://docs.datadoghq.com/integrations/ecs_fargate/#data-collected

タスクの停止時のイベントを取得する方法は下記を参考にする。
https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/ecs_cwet2.html